### PR TITLE
chore(icons): move icons to /public/icons and stop external links

### DIFF
--- a/my-app/app/page.tsx
+++ b/my-app/app/page.tsx
@@ -6,7 +6,7 @@ export default function Home() {
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <Image
           className="dark:invert"
-          src="https://nextjs.org/icons/next.svg"
+          src="/icons/next.svg"
           alt="Next.js logo"
           width={180}
           height={38}
@@ -33,7 +33,7 @@ export default function Home() {
           >
             <Image
               className="dark:invert"
-              src="https://nextjs.org/icons/vercel.svg"
+              src="/icons/vercel.svg"
               alt="Vercel logomark"
               width={20}
               height={20}
@@ -59,7 +59,7 @@ export default function Home() {
         >
           <Image
             aria-hidden
-            src="https://nextjs.org/icons/file.svg"
+            src="/icons/file.svg"
             alt="File icon"
             width={16}
             height={16}
@@ -74,7 +74,7 @@ export default function Home() {
         >
           <Image
             aria-hidden
-            src="https://nextjs.org/icons/window.svg"
+            src="/icons/window.svg"
             alt="Window icon"
             width={16}
             height={16}
@@ -89,7 +89,7 @@ export default function Home() {
         >
           <Image
             aria-hidden
-            src="https://nextjs.org/icons/globe.svg"
+            src="/icons/globe.svg"
             alt="Globe icon"
             width={16}
             height={16}

--- a/my-app/public/icons/file.svg
+++ b/my-app/public/icons/file.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><path d="M14 2v6h6"/></svg>

--- a/my-app/public/icons/globe.svg
+++ b/my-app/public/icons/globe.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M2 12h20"/><path d="M12 2a15 15 0 0 1 0 20M12 2a15 15 0 0 0 0 20"/></svg>

--- a/my-app/public/icons/next.svg
+++ b/my-app/public/icons/next.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" fill="none" stroke="currentColor" stroke-width="16" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M48 208V48l160 160V48"/></svg>

--- a/my-app/public/icons/vercel.svg
+++ b/my-app/public/icons/vercel.svg
@@ -1,0 +1,4 @@
+<!-- public/icons/vercel.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 222" fill="#fff" aria-hidden="true">
+  <path d="M128 0L256 222H0z"/>
+</svg>

--- a/my-app/public/icons/window.svg
+++ b/my-app/public/icons/window.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="3" y="5" width="18" height="14" rx="2"/><path d="M3 9h18"/><circle cx="7" cy="7" r="1"/><circle cx="11" cy="7" r="1"/><circle cx="15" cy="7" r="1"/></svg>


### PR DESCRIPTION
## 概要
外部アイコン（`https://nextjs.org/icons/*.svg` / `https://vercel.com/icons/*.svg`）への直リンクを廃止し、`/public/icons` にローカル配布へ統一。あわせて Vercel ロゴが黒背景ボタン上で見えない問題を修正。

## 目的 / 背景
- 外部サイトのアセットパス変更・ブロックでアイコンが消える不安定さを解消
- ダーク/ライト切替時も確実に視認できるようにする（特に Vercel ロゴ）

## 変更内容
- `public/icons/` を新規追加：`next.svg`, `vercel.svg`, `file.svg`, `window.svg`, `globe.svg`
  - `vercel.svg` は `fill="#fff"` に変更し、`dark:invert` で反転対応
- `app/page.tsx` の `src` を外部URL → `/icons/*.svg` に差し替え
- （該当する場合）`next.config.mjs` から外部画像ドメイン許可を削除

## 動作確認（手順）
1. `npm run dev`
2. トップページ表示：Nロゴ・Vercel三角・フッターアイコンが表示される
3. **ライト/ダーク切替**：Vercelロゴが常にコントラスト良好
4. **モバイル幅**でも崩れがない

## スクリーンショット
<img width="2371" height="1203" alt="Screenshot 2025-09-07 at 18 26 17" src="https://github.com/user-attachments/assets/b4104ac5-908b-4ecf-a04c-b0cbd63615c7" />


## 影響範囲 / リスク
- 低。パスの差し替えとアセット追加のみ
- リスク：`/public/icons/*.svg` のファイル名が変わると参照切れになる

## ロールバック
- `app/page.tsx` の `src` を元の外部URLへ戻す
- `public/icons` のファイル削除

## 補足
- 教材用スナップショット：`02-icons` タグを作成予定
- 今後、新規アイコンは `/public/icons/` へ追加する方針
